### PR TITLE
Artifact Storage V4 Compatibility

### DIFF
--- a/.github/workflows/archive-contributions.yml
+++ b/.github/workflows/archive-contributions.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Store Contribution Data
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 #v4.0.0
         with:
-          name: contribution-data
+          name: contribution-data-${{ matrix.gqlQuery.forYear }}
           path: ./${{ matrix.gqlQuery.forYear }}.json
   record:
     needs: fetch
@@ -83,8 +83,9 @@ jobs:
       - name: Get Contribution Data
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: contribution-data
+          merge-multiple: true
           path: contributions
+          pattern: contribution-data-*
       - name: Submit Manifests
         uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # v9.1.3
         with:

--- a/contributions/2023.json
+++ b/contributions/2023.json
@@ -2,7 +2,7 @@
   "user": {
     "contributionsCollection": {
       "contributionCalendar": {
-        "totalContributions": 3511,
+        "totalContributions": 3532,
         "weeks": [
           {
             "contributionDays": [
@@ -1599,8 +1599,48 @@
                 "date": "2023-12-15"
               },
               {
-                "contributionCount": 0,
+                "contributionCount": 4,
                 "date": "2023-12-16"
+              }
+            ]
+          },
+          {
+            "contributionDays": [
+              {
+                "contributionCount": 5,
+                "date": "2023-12-17"
+              },
+              {
+                "contributionCount": 1,
+                "date": "2023-12-18"
+              },
+              {
+                "contributionCount": 3,
+                "date": "2023-12-19"
+              },
+              {
+                "contributionCount": 3,
+                "date": "2023-12-20"
+              },
+              {
+                "contributionCount": 2,
+                "date": "2023-12-21"
+              },
+              {
+                "contributionCount": 1,
+                "date": "2023-12-22"
+              },
+              {
+                "contributionCount": 1,
+                "date": "2023-12-23"
+              }
+            ]
+          },
+          {
+            "contributionDays": [
+              {
+                "contributionCount": 1,
+                "date": "2023-12-24"
               }
             ]
           }


### PR DESCRIPTION
Changes to `v4` of the `artifact-upload` action included one that made artifacts immutable once they were uploaded. In most cases, this is not an issue, and the benefit of the change is a substantial increase in performance.

In some cases, particularly when `matrix` is used in a workflow, it was not uncommon for each job in the matrix to add content to the artifact to be processed later. That was the case here, but fortunately, the action developers provided a way to achieve the same goal.

### Reference
- https://github.com/actions/upload-artifact/tree/v4.0.0?tab=readme-ov-file#breaking-changes
- https://github.com/actions/download-artifact/tree/v4.1.0?tab=readme-ov-file#breaking-changes